### PR TITLE
ci: add monthly Dependabot PR digest workflow

### DIFF
--- a/.github/workflows/dependabot-digest.yml
+++ b/.github/workflows/dependabot-digest.yml
@@ -1,0 +1,47 @@
+name: Dependabot Monthly Digest
+
+on:
+  schedule:
+    - cron: '0 8 1 * *' # 08:00 UTC on the 1st of every month
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
+jobs:
+  digest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build and post digest issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+
+          prs_json=$(gh pr list --repo "$REPO" --search "author:app/dependabot" --state open --json number,title,url,createdAt)
+          count=$(echo "$prs_json" | jq 'length')
+
+          if [ "$count" -eq 0 ]; then
+            echo "No open Dependabot PRs this month, skipping."
+            exit 0
+          fi
+
+          month=$(date -u +"%B %Y")
+
+          {
+            echo "### ${count} open Dependabot pull request(s) as of $(date -u +%Y-%m-%d)"
+            echo
+            echo "$prs_json" | jq -r '.[] | "- [#\(.number)](\(.url)) \(.title) (opened \(.createdAt | split("T")[0]))"'
+            echo
+            echo "_Routine monthly check. Security alerts for serious vulnerabilities are sent immediately via GitHub's own Dependabot alert notifications, separate from this digest._"
+          } > /tmp/digest-body.md
+
+          gh issue create --repo "$REPO" \
+            --title "Dependabot PR digest - ${month}" \
+            --body-file /tmp/digest-body.md \
+            --assignee "$OWNER" \
+            --label "dependencies"


### PR DESCRIPTION
## Summary
- Adds a scheduled GitHub Action that runs on the 1st of each month, checks for open Dependabot PRs, and (if any exist) opens a GitHub issue assigned to the repo owner summarizing them.
- Uses only the built-in `GITHUB_TOKEN` — no secrets to configure. The email arrives via GitHub's existing "you were assigned an issue" notification, which is on by default.
- Serious vulnerabilities are handled separately: vulnerability alerts + automated security fixes are now enabled on the repo, so GitHub will email immediately via its native Dependabot alert notifications (separate from this monthly digest, no Action needed for that part).

## Test plan
- [x] Workflow YAML validated locally for syntax.
- [ ] After merge, trigger manually once via `gh workflow run "Dependabot Monthly Digest" --repo berntisak/kilele-web` to confirm it creates the issue correctly.